### PR TITLE
fix missing snipcart script on store pages

### DIFF
--- a/_includes/scripts/snipcart.html
+++ b/_includes/scripts/snipcart.html
@@ -1,9 +1,0 @@
-{% unless HAVE_SNIPCART %}
-{% assign HAVE_SNIPCART=1 %}
-{% comment %}we suppose that jquery is always already loaded{%endcomment%}
-<script defer src="https://cdn.snipcart.com/scripts/2.0/snipcart.js"
-  data-api-key="{{ site.snipcart_api_key }}"
-  data-autopop="true"
-  id="snipcart"></script>
-<link href="https://cdn.snipcart.com/themes/2.0/base/snipcart.min.css" rel="stylesheet" type="text/css" />
-{% endunless %}

--- a/_layouts/store.html
+++ b/_layouts/store.html
@@ -3,7 +3,12 @@ layout: index
 ---
 
 
-{% include scripts/snipcart.html %}
+{% comment %}we suppose that jquery is always already loaded{%endcomment%}     
+<script defer src="https://cdn.snipcart.com/scripts/2.0/snipcart.js"           
+  data-api-key="{{ site.snipcart_api_key }}"                                   
+    data-autopop="true"
+      id="snipcart"></script>
+      <link href="https://cdn.snipcart.com/themes/2.0/base/snipcart.min.css" rel="stylesheet" type="text/css" />
 
 <div class="container-fluid cart-icon-line">
   <div id="open-cart" class="snipcart-summary">


### PR DESCRIPTION
Fix broken store pages that were not loading snipcart's script since 72d3c6b52e02394be19836dbf370b6e0019fb0b5