### PR TITLE
Image SEO: fix og:image, add image sitemap, lazy-loading, alt text

### DIFF
--- a/_content_dev/en/index.html
+++ b/_content_dev/en/index.html
@@ -18,7 +18,7 @@
 
 <section id="section-gamme" class="section-tile">
   <div class="tile-image-wrapper">
-    <img class="img-fluid" style="object-fit:cover"  src="/static/img/products/iris75_h_et_v.jpg">
+    <img alt="Iris 75 hologram generator shown in horizontal and vertical orientation" class="img-fluid" style="object-fit:cover"  src="/static/img/products/iris75_h_et_v.jpg">
   </div>
   <div class="tile-body tile-body--main">
     <h3>Where to start ?</h3>

--- a/_content_dev/fr/index.html
+++ b/_content_dev/fr/index.html
@@ -18,7 +18,7 @@
 
 <section id="section-gamme" class="section-tile">
   <div class="tile-image-wrapper">
-    <img class="img-fluid" style="object-fit:cover"  src="/static/img/products/iris75_h_et_v.jpg">
+    <img alt="Générateur d'hologrammes Iris 75 en orientation horizontale et verticale" class="img-fluid" style="object-fit:cover"  src="/static/img/products/iris75_h_et_v.jpg">
   </div>
   <div class="tile-body tile-body--main">
     <h3>Où commencer?</h3>

--- a/_content_dev/fr/references/control-api.md
+++ b/_content_dev/fr/references/control-api.md
@@ -6,7 +6,7 @@ rank: 1
 ---
 
 <div class="row">
-  <div class="col-lg-6 col-md-12"><img class="img-fluid" src="/static/img/posts/media-player/header2.png"></div>
+  <div class="col-lg-6 col-md-12"><img alt="Interface de l'API de contrôle du media player Holusion" class="img-fluid" src="/static/img/posts/media-player/header2.png"></div>
   <div class="col-lg-6 col-md-12">
   <p>Holusion fournit une API publique sur chacun de ses produits. Elle permet de contrôler l'activation, la désactivation, l'ajout ou la suppression ainsi que la lecture des médias.
   </p><p>

--- a/_css/_medias.scss
+++ b/_css/_medias.scss
@@ -64,6 +64,20 @@
   padding: 0;
   overflow: hidden;
 
+  /* A clipping wrapper becomes the scroll container for a sticky child, which
+     stops it sticking (it scrolls away with the page). Media that wraps a
+     sticky element (e.g. the Lascaux 3D embed) must not clip it. */
+  &:has(> .sticky-top){
+    overflow: visible;
+    /* Bootstrap pins .sticky-top at top:0, which tucks it under the fixed
+       navbar (#navbar-top, ~58px tall). Offset it to rest just below the
+       navbar and size it to the remaining viewport height. */
+    > .sticky-top{
+      top: 4rem;
+      height: calc(100vh - 4rem);
+    }
+  }
+
   iframe, object, video, img{
     display:block;
     max-width:100%;

--- a/_data/picture.yml
+++ b/_data/picture.yml
@@ -16,31 +16,44 @@ presets:
     <<: *base
     widths: [400, 800, 1200]
     fallback_width: 800
+    dimension_attributes: true
+    attributes:
+      img: 'loading="lazy" decoding="async"'
   grid:
     <<: *base
     widths: [960, 1280]
     fallback_width: 960
     formats: [webp, original]
+    dimension_attributes: true
     sizes:
       xl: 50vw
     size: 100vw
+    attributes:
+      img: 'loading="lazy" decoding="async"'
   header:
+    # Header is the above-the-fold hero (usually the LCP element): keep it
+    # eager and hint high priority rather than lazy-loading it.
     <<: *base
     formats: [webp, original]
     widths: [480, 960, 1280, 1920, 3072, 3840]
     fallback_width: 960
     dimension_attributes: true
     size: 100vw
+    attributes:
+      img: 'decoding="async" fetchpriority="high"'
   card:
     <<: *base
     formats: [webp, original]
     widths: [400, 800]
     fallback_width: 400
+    dimension_attributes: true
     sizes:
       xl: 25vw
       lg: 33vw
       md: 50vw
     size: 100vw
+    attributes:
+      img: 'loading="lazy" decoding="async"'
   container:
     <<: *base
     formats: [webp, original]
@@ -52,11 +65,16 @@ presets:
       lg: 960px
       md: 720px
     size: 100vw
+    attributes:
+      img: 'loading="lazy" decoding="async"'
   portrait:
     formats: [original]
     widths: [256, 512]
     fallback_width: 256
     size: 256px
+    dimension_attributes: true
+    attributes:
+      img: 'loading="lazy" decoding="async"'
   direct_portrait:
     markup: direct_url
     fallback_width: 256

--- a/_includes/components/medias/hover_image.html
+++ b/_includes/components/medias/hover_image.html
@@ -2,7 +2,7 @@
   <img class="logo-image-front shadow img-fluid" src="{{include.src}}" alt="{{include.alt}}"/>
   {% if include.hover %}
     <div class="logo-image-back shadow">
-      <img class="img-fluid" src="{{include.hover}}">
+      <img alt="" class="img-fluid" src="{{include.hover}}">
     </div>
   {%endif%}
 </div>

--- a/_layouts/front_page.html
+++ b/_layouts/front_page.html
@@ -25,8 +25,8 @@
       <meta name="twitter:image"  content="{{site.url}}{{page.image}}">
       <meta property="og:image" content="{{site.url}}{{page.image}}"/>
     {%- else -%}
-      <meta name="twitter:image"  content="{% picture meta "{{page.image}}" %}">
-      <meta name="og:image"  content="{% picture meta "{{page.image}}" %}">
+      <meta name="twitter:image"  content="{{site.url}}{% picture meta "{{page.image}}" %}">
+      <meta property="og:image"  content="{{site.url}}{% picture meta "{{page.image}}" %}"/>
     {%- endif -%}
   {%- endif -%}
   {%- if page.layout == "post" -%}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,6 +9,13 @@ layout: front_page
 
 <main class="container text-white" id="content" itemscope itemtype="http://schema.org/Article">
   <meta itemprop="abstract" content="{{page.abstract}}"/>
+  {%- if page.image -%}
+    {%- if page.image contains "static/" -%}
+      <meta itemprop="image" content="{{site.url}}{{page.image}}"/>
+    {%- else -%}
+      <meta itemprop="image" content="{{site.url}}{% picture meta "{{page.image}}" %}"/>
+    {%- endif -%}
+  {%- endif -%}
   <div itemprop="articleBody" id="post-content">
   {{content}}
   </div>

--- a/en/_posts/2024-05-14-lascaux3D.html
+++ b/en/_posts/2024-05-14-lascaux3D.html
@@ -6,7 +6,7 @@ abstract: Une visite en ligne de la plus célèbre grotte peinte de France
 tags: Explanations Holograms cultural mediation
 ---
 
-<script async src="https://man.ecorpus.holusion.com/dist/js/voyager-explorer.js"></script>
+<script async src="https://archeologie.ecorpus.eu/dist/js/voyager-explorer.js"></script>
 
 <style>
   .content [data-step] {
@@ -27,7 +27,7 @@ tags: Explanations Holograms cultural mediation
     <div class="media">
       <div class="d-flex sticky-top flex-column justify-content-center" style="height: calc(100vh - 3rem)">
         <div class="">
-          <voyager-explorer id="Lascaux" lang="EN" resourceRoot="https://man.ecorpus.holusion.com/dist/" root='https://man.ecorpus.holusion.com/scenes/Lascaux_API/' document='scene.svx.json'></voyager-explorer>
+          <voyager-explorer id="Lascaux" lang="EN" resourceRoot="https://archeologie.ecorpus.eu/dist/" root='https://archeologie.ecorpus.eu/scenes/Lascaux_API/' document='scene.svx.json'></voyager-explorer>
         </div>
       </div>
     </div>
@@ -84,7 +84,7 @@ tags: Explanations Holograms cultural mediation
         <p>
           Just a few days earlier, while chasing his dog, Robot, the young Marcel Ravidat made an intriguing discovery. A hole had opened in the ground near the Lascaux estate. However, he lacked the time and equipment to explore further.
         </p>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_Robot.jpg">
+        <img alt="Robot, the dog credited with the 1940 discovery of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_Robot.jpg">
         <figcaption>The dog named Robot © INA Archive</figcaption>
         <p>
           So, he returned with three friends: Jacques Marsal, Georges Arniel, and Simon Coencas, two Parisian refugees fleeing the occupation and the war. Together, they explored what they believed to be a secret underground passage leading to the nearby mansion.
@@ -95,7 +95,7 @@ tags: Explanations Holograms cultural mediation
         <p>
           After enlarging the opening and descending onto a cone of rubble at the bottom of the cavity, they began to explore what appeared to be a large cave with several branching tunnels.
         </p>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_EntreeTrou.jpg">
+        <img alt="One of the teenagers who discovered Lascaux sliding into the cave entrance" class="img-fluid" src="/static/img/posts/2024_lascaux/00_EntreeTrou.jpg">
         <figcaption>One of the teenagers sliding into the cave © INA Archive</figcaption>
     </div>
   
@@ -111,7 +111,7 @@ tags: Explanations Holograms cultural mediation
 
 
         </p>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_Eclairage.jpg">
+        <img alt="Abbé Breuil studying the Unicorn painting inside the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_Eclairage.jpg">
         <figcaption>Abbé Breuil in front of the famous unicorn</figcaption>
 
       </div>
@@ -147,7 +147,7 @@ tags: Explanations Holograms cultural mediation
 
       <div data-step="6" class='text-center'>
         <h2>The Bulls' Chamber</h2>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
+        <img alt="3D digitisation of the Bulls' Chamber in the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
         <p>
           Three animal themes compose this vast ensemble: the horse, with 17 individuals; the aurochs, including eleven cows and bulls; and the stag, with six representatives. These themes recur throughout the various subterranean spaces of this sanctuary. The bear is exceptionally present.
         </p>
@@ -160,7 +160,7 @@ tags: Explanations Holograms cultural mediation
       <p>
         Upon entering the Rotunda, one's gaze is drawn to an animal with strange forms, the Unicorn. In a leading position, it appears to push all the animals on this wall towards the back of the gallery.
       </p>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/Licorne.jpg">
+      <img alt="The Unicorn cave painting of Lascaux reproduced in 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/Licorne.jpg">
       <p>
         This figure features wavy lines that might suggest a feline presence. With its square head, prominent shoulder, swollen belly, and robust legs, it would seem to support this interpretation. However, two straight horns extending a third of the figure's length suggest categorizing this animal as a mythical creature. Various interpretations have been proposed, but none are currently satisfactory.
       </p>
@@ -170,7 +170,7 @@ tags: Explanations Holograms cultural mediation
       <p>
         In front of the Unicorn, a frieze of eight black horses stretches for 9 meters towards the back of the cavity. These horses, whether complete, partial, or limited to a single anatomical segment, appear to move along the same ground line, marked both by a change in the surface color and by the return of the wall created by the bench. The technique used for the entire frieze is consistent: blowing and stenciling.
       </p>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/Chevaux.jpg">
+      <img alt="The Black Horses Frieze of the Lascaux cave in 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/Chevaux.jpg">
       <p>
         The first horse was originally complete. Due to deterioration of the surface, a large flake detached from the wall, taking part of the painting with it. On this flake, now located at the base of the panel, the outlines of the head and neck can still be seen. Another complete horse, the fourth horse, situated in the center of the frieze, is depicted in extension, with only the hind legs resting on the imaginary ground line. Its massive neck contrasts with its reduced head. The mottled appearance of its coat is due to the differential preservation of pigments, better in the concavities than on the protrusions of the rock. Several horses are incomplete, limited to the forequarters (second horse), the head, neck, and start of the back (third horse), or a faint silhouette including the head, neck, and start of the back (fifth horse). The seventh and eighth horses are only sketched.
       </p>
@@ -178,7 +178,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="9" class='text-center'>
       <h2>The Axial Gallery</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleAxial.jpg">
+      <img alt="3D reconstruction of the Axial Gallery in the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleAxial.jpg">
       <p>
         In this passage, about thirty meters long, the figures are distributed across both walls. On the right, there are three panels: the Chinese Horses Panel, the Falling Cow Panel, and the Red Panel, featuring two horses and a bison; on the left, the Red Cows Panel, the Great Black Bull Panel, the Hemione Panel, and, at the end, the Reversed Horse Locus. The decoration includes 161 graphic entities, of which 58 are figurative representations, primarily animals; 46 are geometric signs, including quadrangular, tree-like, straight, interlocking elements, dotted patterns, or cruciform shapes. There are 57 indeterminate figures that could be interpreted as signs or sketches of animal figures.
       </p>
@@ -188,7 +188,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="10" class='text-center'>
       <h2>A Naturalistic Approach</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_01.jpg">
+      <img alt="Naturalistic animal paintings in the Axial Gallery of Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_01.jpg">
       <p>
         The Chinese Horses depicted here, three in total, feature prominently in many discussions of parietal art. These figures reflect a more naturalistic approach to form, as well as a closer observation of coat patterns. The overlapping of solid colors, created from contrasting shades of black and yellow, allows for a more accurate reproduction of the coat's chromatic variations.
       </p>
@@ -211,7 +211,7 @@ tags: Explanations Holograms cultural mediation
         Another painting technique used is juxtaposed punctuation. This technique is notably found on two confronting ibexes at the back of the space. The lines of the black ibex are particularly precise compared to the other figures at this site. The graphic quality of its yellow counterpart is noticeably lower.
       </p>
 
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_02.jpg">
+      <img alt="Superimposed frescoes of the Axial Gallery suggesting movement, in Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_02.jpg">
 
       <p>
         The Great Black Bull can be considered the most emblematic work, not only of Lascaux but also of all Paleolithic decorated caves and shelters. While the fresco impresses with its imposing depiction of the bull, the discerning eye will recognize hidden forms within the bull’s black coat. Red images of two cows can be seen, as well as four yellow protomes of aurochs, with their horns being the most visible, protruding from the back of the Great Black Bull, whose contours conceal much of the figure.
@@ -220,10 +220,10 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="12" class='text-center'>
       <h2>The Bear Panel</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
+      <img alt="The Bear Panel in the Bulls' Chamber of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
       <p>Upon reaching the end of the Axial Gallery, we must return to the Bulls' Chamber before we can continue to the Passage site. While the left side of the wall is notable for its depiction of the "Unicorn," the right side is equally unique for its rare representation of a Black Bear.</p>
 
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/01_SalleDesTaureaux_07.jpg">
+      <img alt="Close-up of the bear hidden within the Bulls' Chamber panel at Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/01_SalleDesTaureaux_07.jpg">
 
       <p>
         The uniqueness of this bear representation lies in both its rarity and its concealment within the broad black area of the third bull's belly. Total overlays are indeed rare. However, the head and shoulder of the bear, as well as its right hind leg, drawn with three claws, emerge from this ventral area. The image treatment allows us to distinguish the hue used for the aurochs from that of the bear and to discern the graphic outline of the bear, which is missing only the forelegs and the ventral line. The figure is later than the bull; it was created by spraying, with the tip of the nose, the contour of the ears, and the three claws done with a brush. Its muzzle is comparable to that of some horses.
@@ -234,14 +234,14 @@ tags: Explanations Holograms cultural mediation
     <div data-step="13" class='text-center'>
 
       <h2>The Passage</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePassage.jpg">
+      <img alt="The Passage gallery of the Lascaux cave digitised in 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePassage.jpg">
       <p>
         The Passage connects the Bulls' Chamber to the Nave and the Apse. It is characterized by a high density of representations that are often challenging to interpret. Several hundred figures, including 385 precisely counted and identified, are found here: horses, bison, ibexes, bovids, stags, and various signs such as hook shapes, crosses, and quadrangular forms.
       </p>
 
 
       <h2>The Rolling Horse</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/03_LePassage_01.jpg">
+      <img alt="The Rolling Horse figure in the Passage of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/03_LePassage_01.jpg">
       <p>
         Some animal figures in the Passage are notable for their animation or the treatment of anatomical segments. These characteristics are evident in the Equid with the turned leg, which occupies the center of a composition featuring about ten equids. Another example is the Rolling Horse. It shares this very rare animation with the Falling Cow, a figure from the Axial Gallery. To facilitate interpretation, its contours have been intentionally highlighted. While the forequarters show no particular features, the entire rear, including the rump and hind legs, has undergone twisting. This movement may not be a result of a fall, like the aurochs in the Axial Gallery, but rather a specific action of some animals rolling on the ground or preparing to get up.
       </p>
@@ -250,7 +250,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="14" class='text-center'>
       <h2>The Nave</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LaNef.jpg">
+      <img alt="3D digitisation of the Nave in the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LaNef.jpg">
       <p>
         The left wall features four panels: the Seven Ibexes Panel, the Imprint Panel, the Great Black Cow Panel, and the Back-to-Back Bison Panel. The right wall is occupied solely by the Swimming Stags Frieze. The slope of the floor has led to the distribution of the panels on different levels. The figurative themes include horses, ibexes, stags, bison, and aurochs, with very different proportions where the equids, as in every sector of the cave, overwhelmingly dominate the fauna with 27 individuals here. In contrast, the aurochs, notable for its massive silhouette and central position in this vast composition, is represented only once, while the ibex is depicted nine times, the bison five times, and the stag six times.
 
@@ -273,7 +273,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="15" class='text-center'>
       <h2>The Heraldries</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_01.jpg">
+      <img alt="The Heraldic signs painted in the Nave of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_01.jpg">
       <p>
         The quadrangular signs on the Great Black Cow panel, commonly referred to as "Heraldries," have distinct characteristics that set them apart from other similar figures. Each entity is constructed from juxtaposed colored areas in square or rectangular shapes. An engraved line completes the partitioning of these figures. The colors are the same as those used for the figurative representations, although a purple hue appears only on two of these signs. It is noteworthy that the ends of the hind legs and the tail of the black aurochs are in contact with the upper left edge of each of these signs. Various interpretations have been proposed: grids, hunting traps, tribal symbols used as armoiries; however, in this context, none fully satisfies scholarly scrutiny.
       </p>
@@ -282,7 +282,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="16" class='text-center'>
       <h2>The Back-to-Back Bison</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_02.jpg">
+      <img alt="The Back-to-Back Bison painting in the Nave of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_02.jpg">
       <p>
         This diptych of back-to-back bison concludes the long succession of panels that adorn the left wall. Its originality lies not only in the proposed animation, with two mirrored male bison, but also in the accumulation of graphic conventions used to emphasize the fleeing movement of the two antagonists in this composition. In this perspective, it is noticeable that the legs in the background are detached from the body, unlike those in the foreground. A gap separates the two rumps, bringing the bison on the left to the forefront. The forelegs are more detailed than the hind legs, with a deliberate degradation of the forms simulating their distance from the observer. The wall itself contributes to this relief effect of the figures; its incline towards the observer enhances the fleeing effect given to the composition.
       </p>
@@ -290,7 +290,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="17" class='text-center'>
       <h2>The Feline Gallery</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleDesFelins.jpg">
+      <img alt="3D reconstruction of the Feline Gallery in the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleDesFelins.jpg">
       <p>
         The Feline Gallery extends over approximately 25 meters. More than 80 figures have been recorded here by André Glory. Of the 51 animal figures in this gallery, horses dominate with twenty-nine individuals, followed by bison with nine, ibexes with four, and stags with three. No aurochs are present. The felines hold a more prominent place here compared to the rest of the cave, with six individuals represented. The distribution of the figures is uneven; 90% of them are located in the first few meters of the passage, which is the narrowest segment of this area.
 
@@ -299,7 +299,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="18" class='text-center'>
       <h2>Feline</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_03.jpg">
+      <img alt="Engraving of a feline in the Feline Gallery of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_03.jpg">
       <p>
         The feline theme is not frequently represented in Paleolithic parietal art, with the Chauvet-Pont-d’Arc cave being a notable exception, and it often occupies a special place within the sanctuary. Most often, felines are found in the most remote areas; those in Lascaux adhere to this convention. There are six of them, distributed on either side of the entrance to the gallery, in a rigorously symmetrical composition. On each wall, two are directed towards the back, and the third towards the entrance. Another characteristic that aligns them with other felines in this domain of parietal art is the average quality of the graphic depiction.
 
@@ -309,7 +309,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="19" class='text-center'>
       <h2>The Elevated Hut</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_01.jpg">
+      <img alt="The 'elevated hut' sign in the Feline Gallery of Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_01.jpg">
 
       <p>
 
@@ -320,7 +320,7 @@ tags: Explanations Holograms cultural mediation
 
 
       <h2>Horse Seen from the Front</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_02.jpg">
+      <img alt="Horse depicted from the front in the Feline Gallery of Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_02.jpg">
 
       <p>
 
@@ -330,14 +330,14 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="20" class='text-center'>
       <h2>The Apse</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LAbside.jpg">
+      <img alt="3D digitisation of the Apse in the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LAbside.jpg">
       <p>
         In a space limited to approximately 30 square meters, with an average height of 3.5 meters, the Apse contains over a thousand figures. Among these, nearly 500 are animals and about 600 are geometric signs or various marks. The figures are distributed across the side walls and the dome-shaped ceiling without interruption. Their density increases from the entrance towards the back, reaching its peak in the apse’s recess, directly beneath the Well, in the most remote part of this chamber. The very soft limestone substrate partly explains this graphic exuberance. While the fame of Lascaux is primarily based on the paintings of the Bulls' Chamber, the Axial Gallery, and the Nave, the high number of figures in the Apse, as well as in the Passage, the Nave, and the Feline Gallery, highlights that Lascaux’s art is predominantly characterized by engraving.
 
       </p>
 
       <h2>The Collapsed Deer</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/06_LAbside_01.jpg">
+      <img alt="The Collapsed Deer engraving in the Apse of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/06_LAbside_01.jpg">
 
       <p>
         The "Collapsed Deer" is one of the major representations in the Apse. Covering an area of nearly 4 square meters, this deer occupies the beginning of the vault near the entrance to the Nave, in a spot where the density of figures is minimal. It stands out due to the bending of its limbs tucked under the animal's belly, in a position that is anatomically unrealistic. On the antlers and limbs, some traces of brown paint remain, and black on the hooves. It is likely that the entire silhouette was originally painted. Two hook-shaped signs, one painted and the other engraved, cross the thorax. It is one of the rare figures where the cause, the signs that could resemble arrows here, and the effect, the collapse of the body, are concurrent.
@@ -349,7 +349,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="21" class='text-center'>
       <h2>The Well</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePuits.jpg">
+      <img alt="The Well shaft of the Lascaux cave digitised in 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePuits.jpg">
       <p>
         In contrast to previous sections—the Apse, the Passage, or the Bulls' Chamber—the Well contains only a limited number of figures, totaling eight. Four belong to the animal repertoire (horse, bison, bird, and rhinoceros), while the remaining three are geometric signs (dots and hook-shaped symbols). At the center of this composition, a human figure captures all the attention. On the right wall, there is a horse, and on the left wall, the other figures are grouped over approximately 3 square meters. This arrangement, made famous by its narrative potential, is one of the rare examples where the animation of the subjects and the chosen themes suggest a particular episode, hinting at the possibility of interpreting a message, hence the name "Scene of the Well" given to this panel.
       </p>
@@ -357,7 +357,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="22" class='text-center'>
       <h2>Man and Bird</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/07_LePuits_01.jpg">
+      <img alt="The Man and Bird scene painted in the Well of the Lascaux cave" class="img-fluid" src="/static/img/posts/2024_lascaux/07_LePuits_01.jpg">
 
 
       <p>

--- a/en/_posts/2024-05-14-lascaux3D.html
+++ b/en/_posts/2024-05-14-lascaux3D.html
@@ -25,9 +25,9 @@ tags: Explanations Holograms cultural mediation
 <main class="main-dark main-grid">
   <section class="section">
     <div class="media">
-      <div class="d-flex sticky-top flex-column justify-content-center" style="height: calc(100vh - 3rem)">
+      <div class="d-flex sticky-top flex-column justify-content-center">
         <div class="">
-          <voyager-explorer id="Lascaux" lang="EN" resourceRoot="https://archeologie.ecorpus.eu/dist/" root='https://archeologie.ecorpus.eu/scenes/Lascaux_API/' document='scene.svx.json'></voyager-explorer>
+          <voyager-explorer id="Lascaux" lang="EN" resourceRoot="https://archeologie.ecorpus.eu/dist/" root="https://archeologie.ecorpus.eu/scenes/Lascaux_API/" document="scene.svx.json" prompt="false"></voyager-explorer>
         </div>
       </div>
     </div>

--- a/en/interaction/index.html
+++ b/en/interaction/index.html
@@ -46,7 +46,7 @@ title: Our interaction examples
     <div class="timeline content py-5">
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/minicontent.webp">
+        <img alt="Holusion Content Manager application icon" src="/static/img/usages/minicontent.webp">
       </span>
       <h3 class="d-inline"><a href="#companion">Holusion Content Management</a></h3>
       <p class="mb-0">
@@ -56,7 +56,7 @@ title: Our interaction examples
 
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/minicorpus.webp">
+        <img alt="eCorpus 3D model viewer icon" src="/static/img/usages/minicorpus.webp">
       </span>
       <h3 class="d-inline"><a href="#ecorpus">eCorpus</a></h3>
       <p class="mb-0">
@@ -67,7 +67,7 @@ title: Our interaction examples
 
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/minitable.webp">
+        <img alt="Tactile interactive table icon" src="/static/img/usages/minitable.webp">
       </span>
       <h3 class="d-inline"><a href="#tactile">Tactile</a></h3>
       <p class="mb-0">
@@ -77,7 +77,7 @@ title: Our interaction examples
 
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/miniboard.webp">
+        <img alt="Custom fabrication icon" src="/static/img/usages/miniboard.webp">
       </span>
       <h3 class="d-inline"><a href="#design">Fabrications sur mesure</a></h3>
       <p class="mb-0">
@@ -142,7 +142,7 @@ title: Our interaction examples
     <div class="content">
       <div class="row">
         <div class="col-lg-6 col-12">
-          <img class="img-fluid" src="/static/img/usages/ethesaurus.webp">
+          <img alt="eCorpus digital thesaurus displaying a 3D collection" class="img-fluid" src="/static/img/usages/ethesaurus.webp">
         </div>
         <div class="col-lg-6 col-12">
           <h3 class="text-center pt-lg-4">With a tactile screen</h3>
@@ -160,7 +160,7 @@ title: Our interaction examples
           </div>
         </div>
         <div class="col-lg-6 col-12">
-          <img class="img-fluid" src="/static/img/usages/table_tactile.webp">
+          <img alt="Visitors interacting with holograms on a tactile table" class="img-fluid" src="/static/img/usages/table_tactile.webp">
         </div>
       </div>
     </div>

--- a/en/posts/index.html
+++ b/en/posts/index.html
@@ -12,7 +12,7 @@ pagination:
 
   <section class="section">
 
-    <img class="img-fluid" style="object-position: 70% 50%" src="/static/img/banners/meduse_bann.jpg">
+    <img alt="Holographic jellyfish banner illustrating storytelling with holograms" class="img-fluid" style="object-position: 70% 50%" src="/static/img/banners/meduse_bann.jpg">
     
     <div class="content">
       <h2 id="main-title-1" >Tell your stories with holograms</h2>

--- a/en/store/fond22.html
+++ b/en/store/fond22.html
@@ -6,7 +6,7 @@ description: With this tailor-made opaque background, you both give more depth t
 
 <section class="section left">
   <h2>Opaque and movable</h2>
-  <img src="/static/img/posts/arc_france/vignette_arc.jpg">
+  <img alt="Iris 22 hologram of a glass against an opaque black background" src="/static/img/posts/arc_france/vignette_arc.jpg">
   <div class="content">
     <p>
       You can use this black background to <b>hide things that could disturb your holographic display</b>, behind your Iris 22. It is completely opaque and it will make your hologram even more visible. It is the perfect object to give more depth to your hologram and to <b>make it shine even brighter.</b>

--- a/en/store/fond32.html
+++ b/en/store/fond32.html
@@ -6,7 +6,7 @@ description: With this tailor-made opaque background, you both give more depth t
 
 <section class="section left">
   <h2>Opaque and movable</h2>
-  <img src="/static/img/posts/arc_france/vignette_arc.jpg">
+  <img alt="Iris 32 hologram of a glass against an opaque black background" src="/static/img/posts/arc_france/vignette_arc.jpg">
   <div class="content">
     <p>
       You can use this black background to <b>hide things that could disturb your holographic display</b>, behind your Iris 32. It is completely opaque and it will make your hologram even more visible. It is the perfect object to give more depth to your hologram and to <b>make it shine even brighter.</b>

--- a/en/store/iris46.html
+++ b/en/store/iris46.html
@@ -1,6 +1,6 @@
 ---
 title: Iris 46
-abstract: A 46" inches holographic showcase.
+abstract: A 46 inches holographic showcase.
 stock: quotation
 
 properties:
@@ -70,7 +70,7 @@ description: |
     <p>
       Or integrate it into your <a href="/en/posts/2021-02-18-PierreDeSeine">marketing process</a>
     </p>
-    <center><img class="img-fluid" style="border-radius: 4px"; src="/static/img/misc/franck_riester.webp"></center>
+    <center><img alt="Franck Riester, French Minister of Culture, in front of a Holusion hologram" class="img-fluid" style="border-radius: 4px"; src="/static/img/misc/franck_riester.webp"></center>
   </div>
 </section>
 
@@ -108,7 +108,7 @@ description: |
     <p>
       Our mastery of this product's design allows us to adapt its shape and structure to fit perfectly into the most constrained spaces.
     </p>
-    <center><img class="img-fluid" style="max-width:100%" src="/static/img/misc/calais.webp"/></center>
+    <center><img alt="Iris 46 hologram displaying the 1900 relief map of Calais" class="img-fluid" style="max-width:100%" src="/static/img/misc/calais.webp"/></center>
   </div>
 </section>
 

--- a/en/store/opal.html
+++ b/en/store/opal.html
@@ -8,7 +8,7 @@ description: |
 
 <section class="section left">
   <h2></h2>
-  <img src="/static/img/products/opal_dodo.jpg">
+  <img alt="Opal holographic display presenting a dodo" src="/static/img/products/opal_dodo.jpg">
   <div class="content m-auto">
     <h2>Composition and functioning</h2>
     <p>

--- a/en/store/touch.html
+++ b/en/store/touch.html
@@ -26,7 +26,7 @@ properties:
     <p>
       The kit consists of a 21" multi-touch capacitive <b>touch screen</b>, a more powerful <b>embedded computer</b> capable of displaying 3D scenes in real time, and a <b>stand</b> connecting the whole to the hologram structure or its stele.
     </p>
-    <center><img class="img-fluid" src="/static/img/misc/chalice_freestyle.webp"/></center>
+    <center><img alt="Touch screen kit beside a Freestyle hologram of a chalice" class="img-fluid" src="/static/img/misc/chalice_freestyle.webp"/></center>
   </div>
 </section>
 

--- a/en/usages/bim.html
+++ b/en/usages/bim.html
@@ -79,21 +79,21 @@ bimViews:
     <h2>3 levels of detail</h2>
     <div class="row" style="text-align:center">
       <div class="col-md-4">
-        <img src="/static/img/usages/picto_360.jpg" />
+        <img alt="Orbital view pictogram: viewing a building's exterior" src="/static/img/usages/picto_360.jpg" />
         <div>
           <strong>Orbital View</strong>
           <p>Easy and accessible solution to simply show a building's external aspect</p>
         </div>
       </div>
       <div class="col-md-4">
-        <img src="/static/img/usages/picto_layer.jpg" />
+        <img alt="Multi-layer pictogram: technical infrastructure and networks" src="/static/img/usages/picto_layer.jpg" />
         <div>
           <strong>Mutli-layers Presentation</strong>
           <p>Display technical infrastructure and networks</p>
         </div>
       </div>
       <div class="col-md-4">
-        <img src="/static/img/usages/picto_3d.jpg"/>
+        <img alt="Real-time 3D pictogram" src="/static/img/usages/picto_3d.jpg"/>
         <div>
           <strong>Realtime 3D</strong>
           <p>Take control over your presentation with absolute freedom</p>

--- a/en/usages/museographie.html
+++ b/en/usages/museographie.html
@@ -32,7 +32,7 @@ title: Modernize museum with holograms
       <div class="content shadow rounded bg-white rounded p-4">
         <div align="center">
           <div style="min-width :200px">
-            <img src="/static/img/usages/picto_infini.jpg" />
+            <img alt="Infinity pictogram symbolising unique museum solutions" src="/static/img/usages/picto_infini.jpg" />
           </div>
         </div>
         <h1 id="main-title-1">Your museum is unique. So are our solutions</h1>

--- a/fr/_posts/2018-10-28-Taiwan.html
+++ b/fr/_posts/2018-10-28-Taiwan.html
@@ -20,7 +20,7 @@ tags: tourisme museographie
 <div class="col-lg-12">
 <p>La culture du Taiwan contemporain est présentée dans le <a href="https://www.cksmh.gov.tw/eng/" caption="site officiel du memorial de CKS" target="_blank"><b>Mémorial de Tchang Kaï-chek</b></a> en partenariat avec le <b>Ministère de la Culture</b>. Plusieurs générateurs d'hologrammes présentent le site du mémorial et son histoire avec un mapping holographique autour de la porte emblématique de l'entrée du site.</p>
 
-  <img class="img-fluid" src="/static/img/posts/taiwan_2018/TKC_hologramme2.jpg" width="100%"/>
+  <img alt="Mapping holographique autour de la porte d'entrée du mémorial de Tchang Kaï-chek à Taïwan" class="img-fluid" src="/static/img/posts/taiwan_2018/TKC_hologramme2.jpg" width="100%"/>
 
 <p><b>Tchang Kaï-Chek</b>, premier président de la République de Chine, a durablement marqué l'image du pays. La création de son mémorial en 1980 célèbre l'avancement de Taïwan et utilise symboliquement le site des anciennes casernes japonaises pour son établissement.</p>
 
@@ -37,7 +37,7 @@ tags: tourisme museographie
 <p>L'hologramme <b>rend vivant</b> le mémorial et la fondation de la Taïwan moderne, comme un trait d'union entre l'histoire mouvementée du XXème siècle et notre période contemporaine. Le soin apporté au projet avec des contenus technologiques, sociaux et de lettres est un encouragement à créer des projets interdisciplinaires qui offrent beaucoup de richesse au public.</p>
 </div>
 <div class="col-lg-4">
-  <img class="img-fluid" src="/static/img/posts/taiwan_2018/TKC_hologramme.jpg"/>
+  <img alt="Hologramme mêlant maquette physique et animations en réalité augmentée au mémorial de Tchang Kaï-chek" class="img-fluid" src="/static/img/posts/taiwan_2018/TKC_hologramme.jpg"/>
 </div>
 </div>
 

--- a/fr/_posts/2024-05-14-lascaux3D.html
+++ b/fr/_posts/2024-05-14-lascaux3D.html
@@ -25,9 +25,9 @@ tags: Explanations Holograms cultural mediation
 <main class="main-dark main-grid">
   <section class="section">
     <div class="media">
-      <div class="d-flex sticky-top flex-column justify-content-center" style="height: calc(100vh - 3rem)">
+      <div class="d-flex sticky-top flex-column justify-content-center">
         <div class="">
-          <voyager-explorer id="Lascaux" lang="FR" resourceRoot="https://archeologie.ecorpus.eu/dist/" root='https://archeologie.ecorpus.eu/scenes/Lascaux_API/' document='scene.svx.json'></voyager-explorer>
+          <voyager-explorer id="Lascaux" lang="FR" resourceRoot="https://archeologie.ecorpus.eu/dist/" root="https://archeologie.ecorpus.eu/scenes/Lascaux_API/" document="scene.svx.json" prompt="false"></voyager-explorer>
         </div>
       </div>
     </div>

--- a/fr/_posts/2024-05-14-lascaux3D.html
+++ b/fr/_posts/2024-05-14-lascaux3D.html
@@ -6,7 +6,7 @@ abstract: Une visite en ligne de la plus célèbre grotte peinte de France
 tags: Explanations Holograms cultural mediation
 ---
 
-<script async src="https://man.ecorpus.holusion.com/dist/js/voyager-explorer.js"></script>
+<script async src="https://archeologie.ecorpus.eu/dist/js/voyager-explorer.js"></script>
 
 <style>
   .content [data-step] {
@@ -27,7 +27,7 @@ tags: Explanations Holograms cultural mediation
     <div class="media">
       <div class="d-flex sticky-top flex-column justify-content-center" style="height: calc(100vh - 3rem)">
         <div class="">
-          <voyager-explorer id="Lascaux" lang="FR" resourceRoot="https://man.ecorpus.holusion.com/dist/" root='https://man.ecorpus.holusion.com/scenes/Lascaux_API/' document='scene.svx.json'></voyager-explorer>
+          <voyager-explorer id="Lascaux" lang="FR" resourceRoot="https://archeologie.ecorpus.eu/dist/" root='https://archeologie.ecorpus.eu/scenes/Lascaux_API/' document='scene.svx.json'></voyager-explorer>
         </div>
       </div>
     </div>
@@ -84,7 +84,7 @@ tags: Explanations Holograms cultural mediation
         <p>
           Quelques jours à peine auparavant en poursuivant son chien, Robot, le jeune Marcel Ravidat a fait une découverte intriguante. Un trou s'ouvre dans le sol à proximité du domaine de Lascaux. Mais il manque de temps et d'équipement pour aller plus loin.
         </p>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_Robot.jpg">
+        <img alt="Robot, le chien à l'origine de la découverte de la grotte de Lascaux en 1940" class="img-fluid" src="/static/img/posts/2024_lascaux/00_Robot.jpg">
         <figcaption>Le chien dénommé Robot ©Archive INA</figcaption>
         <p>
             Alors, il revient accompagné de trois amis, Jacques Marsal, Georges Arniel et Simon Coencas, deux réfugiés parisiens fuyant l'occupation et la guerre. Ensemble, ils explorent ce qu'il pensent être un souterrain secret vers le manoir tout proche.
@@ -95,7 +95,7 @@ tags: Explanations Holograms cultural mediation
         <p>
           Après avoir agrandi l'ouverture et être descendus sur un cône d'eboulis au fond de la cavité, ils commencent à explorer ce qui semble être une grande grotte ramifiées en plusieurs tunnels.
         </p>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_EntreeTrou.jpg">
+        <img alt="Un des adolescents se glissant dans l'entrée de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_EntreeTrou.jpg">
         <figcaption>Un des adolescents se glissant dans la grotte ©Archive INA</figcaption>
     </div>
   
@@ -109,7 +109,7 @@ tags: Explanations Holograms cultural mediation
         <p>
           Soudain, à la lueur de leurs faibles lumières, ils sont face à un spectacle stupéfiant. Ils aperçoivent à la faveur des murs rapprochés de formidables représentations d'animaux qui se déploient sur les parois de la grotte.
         </p>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_Eclairage.jpg">
+        <img alt="L'abbé Breuil devant la Licorne dans la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_Eclairage.jpg">
         <figcaption>L’abbé Breuil devant la fameuse licorne</figcaption>
 
       </div>
@@ -143,7 +143,7 @@ tags: Explanations Holograms cultural mediation
 
       <div data-step="6" class='text-center'>
         <h2>La salle des Taureaux</h2>
-        <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
+        <img alt="Numérisation 3D de la Salle des Taureaux de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
         <p>
           Trois thèmes animaliers composent ce vaste dispositif : le cheval, avec 17 individus, l’aurochs, onze vaches et taureaux et le cerf, six représentants. Ces thèmes se retrouveront de manière récurrente dans les différents espaces souterrains de ce sanctuaire. L’ours est exceptionnellement présent.
         </p>
@@ -156,7 +156,7 @@ tags: Explanations Holograms cultural mediation
       <p>
         Dès l’entrée dans la Rotonde, le regard est attiré par un animal aux formes étranges, la Licorne. En position première, elle semble pousser vers le fond de la galerie tous les animaux de cette paroi.
       </p>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/Licorne.jpg">
+      <img alt="La Licorne de Lascaux reproduite en 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/Licorne.jpg">
       <p>
         Cette figure possède des lignes ondoyantes qui laisseraient à penser que l’on est en présence d’un félin. Une tête carrée, un garrot très saillant, un ventre dilaté, des pattes robustes, inciterait à abonder dans ce sens. Toutefois, deux cornes rectilignes prolongent d’un tiers l’emprise de cette figure, segments anatomiques qui invitent à ranger cet animal dans la catégorie des animaux fantastiques. De multiples interprétations ont été proposées, mais aucune n’est actuellement satisfaisante.
       </p>
@@ -166,7 +166,7 @@ tags: Explanations Holograms cultural mediation
       <p>
         À l’avant de la Licorne, une frise de huit chevaux noirs se déploie sur une longueur de 9 m en direction du fond de la cavité. Ces chevaux, complets, partiels, voire limités à un seul segment anatomique, semblent se déplacer sur une même ligne de sol, matérialisée à la fois par le changement de teinte du support et par le retour de paroi créé par la banquette. La technique de réalisation est identique pour l'ensemble de la frise : soufflé et pochoir.
       </p>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/Chevaux.jpg">
+      <img alt="La Frise des Chevaux noirs de la grotte de Lascaux en 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/Chevaux.jpg">
       <p>
         Le premier cheval devait être complet. Suite à une dégradation du support, une large écaille s’est détachée de la paroi emportant une partie de la peinture. Sur cette plaque de desquamation, déposée actuellement au pied du panneau, on retrouve les contours de la tête et de l’encolure. Autre cheval complet, le quatrième cheval, au centre de la frise, est représenté en extension, seuls les membres postérieurs reposant sur la ligne de sol imaginaire. Son encolure, massive, contraste avec sa tête, réduite. L’aspect pommelé de la robe est dû à la conservation différentielle des pigments, meilleure dans les concavités que sur les aspérités de la roche. Plusieurs chevaux sont incomplets, limités à l'avant-train (deuxième cheval), à la tête, l'encolure et l'amorce du dos (troisième cheval), discrète silhouette incluant la tête, l'encolure et l'amorce du dos (cinquième cheval). Les septième et huitième chevaux sont seulement esquissés.
       </p>
@@ -174,7 +174,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="9" class='text-center'>
       <h2>Le Diverticule Axial</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleAxial.jpg">
+      <img alt="Reconstitution 3D du Diverticule Axial de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleAxial.jpg">
       <p>
         Dans ce conduit long d'une trentaine de mètres, les figures se répartissent sur les deux parois. À droite, trois panneaux : le panneau des Chevaux chinois, le panneau de la Vache qui tombe, puis le panneau rouge, avec deux chevaux et un bison ; à gauche, le panneau des Vaches rouges, le panneau du grand Taureau noir, le panneau de l'Hémione et, au fond, le Locus du cheval renversé. Le décor regroupe 161 entités graphiques, dont 58 représentations figuratives, essentiellement des animaux, 46 signes géométriques, quadrangulaires, arborescents, rectilignes, à éléments emboîtés, en semis de ponctuations ou cruciformes. Il y a 57 figures indéterminées pouvant s’apparenter à des signes, mais aussi à des esquisses de figures animales. 
       </p>
@@ -184,7 +184,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="10" class='text-center'>
       <h2>Une approche naturaliste</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_01.jpg">
+      <img alt="Peintures animalières naturalistes du Diverticule Axial de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_01.jpg">
       <p>
         Les chevaux chinois représentés, ici au nombre de trois, font l'article de nombreuses évocations dans l'art pariétal. Ces figures rendent compte d'une approche plus naturaliste des formes, ainsi que d'une plus grande observation de pelage. Les superpositions des aplats, créés à partir de teintes opposées de noir et de jaune, permettent de reproduire au plus près les variations chromatiques de la robe.
       </p>
@@ -206,7 +206,7 @@ tags: Explanations Holograms cultural mediation
         Un autre type de technique de peinture utilisé est la ponctuation juxtaposée. On la retrouve notamment sur deux bouquetins affrontés présent dans le fond de l'espace. Les traits du bouquetin noir sont notamment très précis par rapport aux autres figures de ce site. On note une moindre qualité graphique de son jumeau jaune.
       </p>
 
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_02.jpg">
+      <img alt="Fresques superposées du Diverticule Axial évoquant le mouvement, à Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/02_DiverticuleAxial_02.jpg">
 
       <p>
         Le grand Taureau noir peut-être qualifiée de l'oeuvre la plus emblématique, non seulement de Lascaux, mais aussi de l'ensemble des grottes et abris ornés paléolithiques. 
@@ -217,10 +217,10 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="12" class='text-center'>
       <h2>le Panneau de l'Ours</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
+      <img alt="Le Panneau de l'Ours dans la Salle des Taureaux de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_SalleDesTaureaux.jpg">
       <p>Arrivant au bout de la Diverticule axial, nous devons retourner dans la salle des Taureaux avant de pouvoir continuer vers le site du Passage. Si le côté gauche du mur est singulier de par sa représentation de "Licorne", le côté droit n'en est pas moins unique, de par sa représentation très rare d'un Ours noir.</p>
 
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/01_SalleDesTaureaux_07.jpg">
+      <img alt="Détail de l'ours dissimulé dans le panneau de la Salle des Taureaux de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/01_SalleDesTaureaux_07.jpg">
 
       <p>
         La particularité de cette représentation d’ours réside à la fois dans son unicité et sa dissimulation dans le large aplat noir du ventre du troisième taureau. Les superpositions totales sont en effet rares. La tête et le garrot de l’ours, ainsi que sa patte postérieure droite, dessinée avec trois griffes, émergent toutefois de cet aplat ventral. Le traitement d’image permet de différencier la teinte utilisée pour l’aurochs de celle de l’ours et de saisir le contour graphique de ce dernier, auquel seules les pattes antérieures et la ligne ventrale manquent. La figure est postérieure au taureau ; elle a été réalisée par pulvérisation, le bout du nez, le contour des oreilles et les trois griffes ayant été effectués au pinceau. Son museau est comparable à celui de certains chevaux.
@@ -231,14 +231,14 @@ tags: Explanations Holograms cultural mediation
     <div data-step="13" class='text-center'>
 
       <h2>le Passage</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePassage.jpg">
+      <img alt="Le Passage de la grotte de Lascaux numérisé en 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePassage.jpg">
       <p>
         Le Passage relie la Salle des Taureaux à la Nef et à l'Abside. Il est caractérisé par une grande densité des représentations d’une lecture souvent difficile. Plusieurs centaines de figures gravées et certaine peintes, 385, plus précisément, y furent dénombrées et identifiées : chevaux, bisons, bouquetins, bovidés, cerfs et des signes à crochet, en croix, quadrangulaires...
       </p>
 
 
       <h2>Le Cheval se Roulant</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/03_LePassage_01.jpg">
+      <img alt="Le Cheval se roulant dans le Passage de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/03_LePassage_01.jpg">
       <p>
         Certaines figures animales du Passage trouvent leur originalité dans l’animation ou le traitement des segments anatomiques. On reconnaît ces marques sur l’Equidé à la patte retournée ; il occupe le centre d’une composition regroupant une dizaine d’équidés. Un autre exemple nous est donné par le Cheval se roulant. Il partage cette l’animation, cependant très rare, avec la Vache qui tombe, figure du Diverticule axial. Pour en faciliter la lecture, nous avons volontairement souligné ses contours. Si l’avant-train ne présente aucune particularité, l’ensemble – croupe et membres postérieurs – a subi une torsion. L’origine de ce mouvement n’est peut-être pas consécutif à une chute, comme l’aurochs du Diverticule axial, mais plutôt à un geste spécifique de certains animaux qui se roulent au sol ou qui se préparent à se relever.
       </p>
@@ -247,7 +247,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="14" class='text-center'>
       <h2>La Nef</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LaNef.jpg">
+      <img alt="Numérisation 3D de la Nef de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LaNef.jpg">
       <p>
         La paroi de gauche regroupe quatre panneaux : celui des sept Bouquetins, de l’Empreinte, de la Grande Vache noire et des Bisons adossés. Celle de droite n’est occupée que par la seule frise des Cerfs nageant. La déclivité du sol est à l’origine de la répartition des panneaux sur différents niveaux. Les thèmes figuratifs se partagent entre cheval, bouquetin, cerf, bison et aurochs, dans des proportions très différentes où les équidés, comme dans chaque secteur de la cavité, dominent largement le bestiaire avec ici un effectif de 27 individus. L’aurochs, en revanche, imposant par sa silhouette massive et sa position au centre de ce vaste dispositif, n’est évoqué qu’une seule fois, alors que le bouquetin est traduit à neuf reprises, le bison, cinq, et le cerf six.
       </p>
@@ -266,7 +266,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="15" class='text-center'>
       <h2>Les Blasons</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_01.jpg">
+      <img alt="Les Blasons peints dans la Nef de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_01.jpg">
       <p>
         Les signes quadrangulaires du panneau de la Grande Vache noire, communément  désignés sous le terme de "blasons", possèdent des caractères qui les singularisent des autres figures de ce type. Chaque entité est construite à partir d’aplats colorés, juxtaposés, de formes carrés ou rectangulaires. Un trait gravé achève le cloisonnement de ces figures. Les couleurs restent identiques à celles utilisées pour les représentations figuratives, cependant, il est une teinte mauve que l’on ne retrouve nulle part ailleurs que sur deux d’entre eux. A noter que les extrémités des membres postérieurs de l’aurochs noir et celle de sa queue sont en contact avec le bord supérieur gauche de chacun de ces signes.
         Les interprétations qui en ont été données sont multiples : grilles, pièges à chasse, signes de tribu employés comme des blasons ; mais, souvent dans ce contexte, aucune ne satisfait pleinement la critique.
@@ -276,7 +276,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="16" class='text-center'>
       <h2>Les Bisons adossés</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_02.jpg">
+      <img alt="Les Bisons adossés peints dans la Nef de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/04_LaNef_02.jpg">
       <p>
         Ce diptyque aux bisons clôt cette longue succession de panneaux qui ornent la paroi de gauche. Il trouve son originalité non seulement dans l’animation proposée, deux bisons mâles peints en miroir, mais aussi dans l’accumulation de conventions graphiques appliquées dans le but d’accentuer le mouvement de fuite donné aux deux belligérants de cette composition. Dans cette mise en perspective, on remarque que les membres du second plan sont détachés du corps, contrairement à ceux du premier. Une réserve sépare les deux croupes, mettant au premier plan le bison de gauche. Les membres antérieurs sont plus achevés que les postérieurs, dégradation volontaire des formes simulant leur éloignement par rapport à l’observateur.
         La paroi participe à cette mise en relief des figures.  son inclinaison vers l’observateur accroît l’effet de fuite donné à la composition.
@@ -285,7 +285,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="17" class='text-center'>
       <h2>Le Diverticule des Félins</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleDesFelins.jpg">
+      <img alt="Reconstitution 3D du Diverticule des Félins de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_DiverticuleDesFelins.jpg">
       <p>
         Le diverticule des Félins se développe sur une longueur d’environ 25 m. Plus de 80 figures y ont été recensées par André Glory. Sur les 51 figures animales de cette galerie, le cheval domine largement avec vingt-neuf individus, puis le bison, neuf, le bouquetin, quatre, et le cerf, trois. Aucun aurochs n’est présent. Les félins prennent ici une place plus importante que dans le reste de la grotte avec six individus. La répartition des figures reste inégale ; 90 % d’entre elles se situent sur les premiers mètres du conduit, segment le plus étroit de ce secteur.
 
@@ -294,7 +294,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="18" class='text-center'>
       <h2>Félin</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_03.jpg">
+      <img alt="Gravure d'un félin dans le Diverticule des Félins de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_03.jpg">
       <p>
         Le thème du félin n’est pas souvent évoqué dans l’art pariétal paléolithique, la grotte Chauvet-Pont-d’Arc faisant exception et occupe souvent une place particulière au sein du sanctuaire. La plupart du temps, les félins sont présents dans les secteurs les plus reculés ; ceux de Lascaux n’échappent pas à cette convention.
         Au nombre de six, ils se répartissent de part et d’autre de l’entrée du diverticule, dans une composition rigoureusement symétrique. Sur chaque paroi, deux sont dirigés vers le fond, le troisième vers l’accès.
@@ -304,7 +304,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="19" class='text-center'>
       <h2>Cabane perchée</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_01.jpg">
+      <img alt="Le signe de la « cabane perchée » dans le Diverticule des Félins de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_01.jpg">
 
       <p>
 
@@ -313,7 +313,7 @@ tags: Explanations Holograms cultural mediation
 
 
       <h2>Cheval vu de Face</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_02.jpg">
+      <img alt="Cheval vu de face dans le Diverticule des Félins de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/05_DiverticuleDesFelins_02.jpg">
 
       <p>
 
@@ -323,7 +323,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="20" class='text-center'>
       <h2>L'Abside</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LAbside.jpg">
+      <img alt="Numérisation 3D de l'Abside de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LAbside.jpg">
       <p>
         Dans un espace limité en surface à quelques 30 m2, pour une élévation moyenne de 3,50 m, l’Abside renferme plus d’un millier de figures. Parmi celles-ci, près de 500 animaux et 600 signes géométriques ou traces diverses. Les figures se répartissent sur les parois latérales et au plafond en coupole, sans discontinuité. Leur densité croît de l’entrée vers le fond, elle est maximale dans l’absidiole qui s’ouvre à l’aplomb du Puits, dans la partie la plus reculée de cette salle. Le support calcaire très tendre explique en partie une telle exubérance graphique.
         La notoriété de Lascaux repose pour l’essentiel sur les peintures de la Salle des Taureaux, du Diverticule axial et de la Nef. Cependant, par le nombre très élevé de figures présentes dans l'Abside, mais aussi dans le Passage, la Nef et le Diverticule des Félins, l'art de Lascaux reste nettement dominé par la gravure. 
@@ -331,7 +331,7 @@ tags: Explanations Holograms cultural mediation
       </p>
 
       <h2>Le Cerf effondré</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/06_LAbside_01.jpg">
+      <img alt="Le Cerf effondré gravé dans l'Abside de la grotte de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/06_LAbside_01.jpg">
 
       <p>
         Le Cerf effondré est une des représentations majeures de l’Abside. D’une emprise de près de 4 m2, ce cervidé occupe l’amorce de la voûte à proximité de l’entrée de la Nef à un emplacement où la densité en figures est minimale.
@@ -345,7 +345,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="21" class='text-center'>
       <h2>Le Puits</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePuits.jpg">
+      <img alt="Le Puits de la grotte de Lascaux numérisé en 3D" class="img-fluid" src="/static/img/posts/2024_lascaux/00_LePuits.jpg">
       <p>
         Par opposition aux secteurs précédents, l’Abside, le Passage ou la Salle des Taureaux – le Puits ne regroupe qu’un nombre restreint de figures. On en compte huit au total. Quatre relèvent du bestiaire (cheval, bison, oiseau et rhinocéros), trois autres du registre géométrique (ponctuations et signes à crochet). Au centre de cette composition, une représentation humaine attire toute l’attention. 
         On remarque sur la paroi de droite un cheval et sur celle de gauche les autres figures regroupées sur environ 3 m2. Ce dispositif, rendu célèbre par son potentiel narratif, est un des rares exemples où l’animation des sujets et les thèmes sollicités témoignent d’un épisode particulier laissant supposer la possibilité d’interprétation d’un message, d’où le nom de « Scène du Puits » donné à ce panneau.
@@ -354,7 +354,7 @@ tags: Explanations Holograms cultural mediation
 
     <div data-step="22" class='text-center'>
       <h2>Homme et oiseau</h2>
-      <img class="img-fluid" src="/static/img/posts/2024_lascaux/07_LePuits_01.jpg">
+      <img alt="La scène de l'Homme et l'oiseau peinte dans le Puits de Lascaux" class="img-fluid" src="/static/img/posts/2024_lascaux/07_LePuits_01.jpg">
 
 
       <p>

--- a/fr/interaction/index.html
+++ b/fr/interaction/index.html
@@ -46,7 +46,7 @@ title: Nos exemples d'interaction
     <div class="timeline content py-5">
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/minicontent.webp">
+        <img alt="Icône de l'application Holusion Content Manager" src="/static/img/usages/minicontent.webp">
       </span>
       <h3 class="d-inline"><a href="#companion">Holusion Content Management</a></h3>
       <p class="mb-0">
@@ -56,7 +56,7 @@ title: Nos exemples d'interaction
 
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/minicorpus.webp">
+        <img alt="Icône du visualiseur de modèles 3D eCorpus" src="/static/img/usages/minicorpus.webp">
       </span>
       <h3 class="d-inline"><a href="#ecorpus">eCorpus</a></h3>
       <p class="mb-0">
@@ -67,7 +67,7 @@ title: Nos exemples d'interaction
 
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/minitable.webp">
+        <img alt="Icône de la table tactile interactive" src="/static/img/usages/minitable.webp">
       </span>
       <h3 class="d-inline"><a href="#tactile">Tactile</a></h3>
       <p class="mb-0">
@@ -77,7 +77,7 @@ title: Nos exemples d'interaction
 
 
       <span class="timeline--point rounded-circle">
-        <img src="/static/img/usages/miniboard.webp">
+        <img alt="Icône des fabrications sur mesure" src="/static/img/usages/miniboard.webp">
       </span>
       <h3 class="d-inline"><a href="#design">Fabrications sur mesure</a></h3>
       <p class="mb-0">
@@ -139,7 +139,7 @@ title: Nos exemples d'interaction
     <div class="content">
       <div class="row">
         <div class="col-lg-6 col-12">
-          <img class="img-fluid" src="/static/img/usages/ethesaurus.webp">
+          <img alt="Thésaurus numérique eCorpus présentant une collection 3D" class="img-fluid" src="/static/img/usages/ethesaurus.webp">
         </div>
         <div class="col-lg-6 col-12">
           <h3 class="text-center pt-lg-4">Avec un écran tactile</h3>
@@ -157,7 +157,7 @@ title: Nos exemples d'interaction
           </div>
         </div>
         <div class="col-lg-6 col-12">
-          <img class="img-fluid" src="/static/img/usages/table_tactile.webp">
+          <img alt="Visiteurs interagissant avec des hologrammes sur une table tactile" class="img-fluid" src="/static/img/usages/table_tactile.webp">
         </div>
       </div>
     </div>

--- a/fr/posts/index.html
+++ b/fr/posts/index.html
@@ -13,7 +13,7 @@ pagination:
 
 <section class="section">
 
-  <img class="img-fluid" style="object-position: 70% 50%" src="/static/img/banners/meduse_bann.jpg">
+  <img alt="Bannière d'un hologramme de méduse illustrant la narration par l'hologramme" class="img-fluid" style="object-position: 70% 50%" src="/static/img/banners/meduse_bann.jpg">
 
   <div class="content">
     <h2 id="main-title-1" >Racontez votre histoire en hologrammes</h2>

--- a/fr/store/fond22.html
+++ b/fr/store/fond22.html
@@ -12,7 +12,7 @@ google_category: 279
 
 <section class="section left">
   <h2>Amovible et opaque</h2>
-  <img src="/static/img/posts/arc_france/vignette_arc.jpg">
+  <img alt="Hologramme Iris 22 d'un verre en cristal sur fond noir opaque" src="/static/img/posts/arc_france/vignette_arc.jpg">
   <div class="content">
     <p>
       Utilisez ce fond occultant en plastique noir pour <b>dissimuler un décor gênant</b> derrière votre borne holographique. 

--- a/fr/store/iris46.html
+++ b/fr/store/iris46.html
@@ -92,7 +92,7 @@ description: |
     <p>
       Ou intégrez-le à votre <a href="/fr/posts/2021-02-18-PierreDeSeine">processus de commercialisation</a>
     </p>
-    <center><img class="img-fluid" style="border-radius: 4px" src="/static/img/misc/franck_riester.webp"></center>
+    <center><img alt="Franck Riester, ministre de la Culture, devant un hologramme Holusion" class="img-fluid" style="border-radius: 4px" src="/static/img/misc/franck_riester.webp"></center>
   </div>
 </section>
 
@@ -130,7 +130,7 @@ description: |
     <p>
       Notre maitrise de la conception de ce produit nous permet d'en adapter sa forme et sa structure pour s'intégrer parfaitement aux espaces les plus contraignants.
     </p>
-    <center><img class="img-fluid" style="max-width:50%" src="/static/img/misc/calais.webp"/></center>
+    <center><img alt="Hologramme Iris 46 présentant le plan-relief de Calais de 1900" class="img-fluid" style="max-width:50%" src="/static/img/misc/calais.webp"/></center>
   </div>
 </section>
 

--- a/fr/store/opal.html
+++ b/fr/store/opal.html
@@ -13,7 +13,7 @@ description: |
 
 <section class="section left">
   <h2></h2>
-  <img src="/static/img/products/opal_dodo.jpg">
+  <img alt="Vitrine holographique Opal présentant un dodo" src="/static/img/products/opal_dodo.jpg">
   <div class="content m-auto">
     <h2>Composition et fonctionnement</h2>
     <p>

--- a/fr/store/touch.html
+++ b/fr/store/touch.html
@@ -32,7 +32,7 @@ properties:
     <p>
       Le kit se compose d'un <b>écran tactile</b> capacitif multipoint 21", d'un <b>ordinateur embarqué</b> plus puissant capable d'afficher des scènes 3D en temps réel et d'un <b>support</b> liant l'ensemble à la structure de l'hologramme ou à sa stèle.
     </p>
-    <center><img class="img-fluid" src="/static/img/misc/chalice_freestyle.webp"/></center>
+    <center><img alt="Kit tactile à côté d'un hologramme Freestyle d'un calice" class="img-fluid" src="/static/img/misc/chalice_freestyle.webp"/></center>
   </div>
 </section>
 

--- a/fr/usages/bim.html
+++ b/fr/usages/bim.html
@@ -76,21 +76,21 @@ bimViews:
     <h2>3 Niveaux de détails</h2>
     <div class="row" style="text-align:center">
       <div class="col-md-4">
-        <img src="/static/img/usages/picto_360.jpg" />
+        <img alt="Pictogramme vue orbitale : aperçu de l'extérieur d'un bâtiment" src="/static/img/usages/picto_360.jpg" />
         <div>
           <strong>Vue Orbitale</strong>
         <p>Solution économique pour présenter en toute simplicité l'aspect extérieur d'un bâtiment</p>
       </div>
       </div>
       <div class="col-md-4">
-        <img src="/static/img/usages/picto_layer.jpg" />
+        <img alt="Pictogramme présentation multi-couches : infrastructures techniques et réseaux" src="/static/img/usages/picto_layer.jpg" />
         <div>
           <strong>Présentation Multi-layers</strong>
           <p>Rentrez dans les détails en explorant les infrastructures techniques</p>
         </div>
           </div>
       <div class="col-md-4">
-        <img src="/static/img/usages/picto_3d.jpg"/>
+        <img alt="Pictogramme 3D temps réel" src="/static/img/usages/picto_3d.jpg"/>
         <div>
           <strong>3D temps réel</strong>
           <p>Prenez la main à 100% sur la présentation pour une exploration en toute liberté</p>

--- a/fr/usages/museographie.html
+++ b/fr/usages/museographie.html
@@ -35,7 +35,7 @@ title: La modernisation des musées par l'hologramme
     <div class="content shadow rounded bg-white rounded p-4">
       <div align="center">
         <div style="min-width :200px">
-          <img src="/static/img/usages/picto_infini.jpg" />
+          <img alt="Pictogramme infini symbolisant des solutions muséographiques uniques" src="/static/img/usages/picto_infini.jpg" />
         </div>
       </div>
       <h1 id="main-title-1">Un accompagnement personnalisé</h1>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,8 @@
+---
+sitemap: false
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ site.url }}/sitemap.xml
+Sitemap: {{ site.url }}/sitemap-images.xml

--- a/sitemap-images.xml
+++ b/sitemap-images.xml
@@ -1,0 +1,25 @@
+---
+sitemap: false
+---
+<?xml version="1.0" encoding="UTF-8"?>
+{%- comment -%}
+  Google image sitemap. jekyll-sitemap only emits page <loc> entries, so
+  images are never advertised for Google Images. This companion sitemap
+  lists every page's primary image (front-matter `image`) as an absolute
+  URL, mirroring the og:image logic in _layouts/front_page.html. It is
+  referenced from robots.txt alongside the standard sitemap.xml.
+{%- endcomment -%}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+{%- assign documents = site.pages | concat: site.posts | concat: site.content_dev -%}
+{%- for doc in documents -%}
+  {%- if doc.image and doc.sitemap != false and doc.url -%}
+  <url>
+    <loc>{{ doc.url | absolute_url }}</loc>
+    <image:image>
+      <image:loc>{% if doc.image contains "static/" %}{{ site.url }}{{ doc.image }}{% else %}{{ site.url }}{% picture meta "{{doc.image}}" %}{% endif %}</image:loc>
+    </image:image>
+  </url>
+  {%- endif -%}
+{%- endfor -%}
+</urlset>


### PR DESCRIPTION
## Why

Images on the site get little search traffic compared to text. Investigation found the root causes: the responsive/WebP image pipeline (`jekyll_picture_tag`) is excellent but barely used for in-content images, several head-level meta bugs, no image sitemap, and widespread missing `alt` text. This PR addresses the structural issues and drafts the missing alt text.

Each concern is a separate commit for easier review.

## Changes

**1. Fix `og:image`/`twitter:image` for pipeline-managed images** (`_layouts/front_page.html`)
The branch handling `_assets/` images emitted a **relative** URL and used `name="og:image"` instead of `property="og:image"`. Open Graph consumers require an absolute URL and the `property` attribute, so social/preview image discovery was broken for every page using the modern image path. Now prepends `site.url` and uses `property=`, matching the working `/static/` branch.

**2. Add image sitemap + robots.txt** (`sitemap-images.xml`, `robots.txt`)
`jekyll-sitemap` advertises page URLs only, so images were never surfaced to Google Images. Adds a companion `sitemap-images.xml` (image sitemap extension) listing each page's primary image as an absolute URL, and a `robots.txt` pointing crawlers at both `sitemap.xml` and the new image sitemap. The standard `sitemap.xml` is left untouched so the existing sitemap e2e tests keep passing.

**3. Article image schema + lazy-loading + dimensions** (`_layouts/post.html`, `_data/picture.yml`)
- Exposes the post's primary image via `itemprop="image"` on the `schema.org/Article` (absolute URL Google recommends for article thumbnails); none was present before.
- Enables `dimension_attributes` (width/height → prevents layout shift/CLS) on all display presets.
- Adds `loading="lazy" decoding="async"` to below-the-fold presets (default/grid/card/container/portrait), while keeping the header hero **eager** with `fetchpriority="high"` to protect LCP.

**4. Draft alt text for content images missing it** (24 files)
Adds `alt` to the 87 in-content `<img>` tags that had none — the strongest relevance signal for image search. Text is drawn from each image's section heading, caption and surrounding copy, in the page's language (FR/EN). The Lascaux 3D posts (24 images each) dominate. **These strings are drafts for editorial review before merge.**

## Not included (larger follow-ups)
- Migrating the ~460 in-content ``'&lt;img src="/static/..."&gt;'`` tags through `jekyll_picture_tag` for responsive/WebP delivery — the single biggest performance win, but a large content-touching refactor.
- Renaming non-descriptive source filenames (e.g. `00_Robot.jpg`, `header2.png`).
- Removing `--ignore-missing-alt` from html-proofer once alt coverage is complete, to block regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3cw2FF2VVVgxUykeb1M7v)_